### PR TITLE
Fix: Broken list items by comma

### DIFF
--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -240,18 +240,15 @@ end
 ---Get a list of playlists from your Apple Music library
 ---@usage require('nvim-apple-music').get_playlists()
 M.get_playlists = function()
-	local command = [[osascript -e 'tell application "Music" to get name of playlists']]
+	local command = [[osascript -e 'tell application "Music" to get name of playlists' -s s]]
 
 	local handle = io.popen(command)
 	local result = handle:read("*a")
 	handle:close()
 
-	-- Split the result into a table of playlist names
-	local playlists = {}
-	for playlist in result:gmatch("([^,]+)") do
-		playlist = playlist:match("^%s*(.-)%s*$")
-		table.insert(playlists, playlist)
-	end
+	-- Convert table string into table
+	local result_chunk = "return " .. result
+	local playlists = loadstring(result_chunk)()
 
 	return playlists
 end
@@ -295,16 +292,14 @@ end
 ---Get a list of albums from your Apple Music library
 ---@usage require('nvim-apple-music').get_albums()
 M.get_albums = function()
-	local command = [[osascript  -e 'tell application "Music" to get album of every track']]
+	local command = [[osascript  -e 'tell application "Music" to get album of every track' -s s]]
 	local handle = io.popen(command)
 	local result = handle:read("*a")
 	handle:close()
-	-- Split the result into a table of album names
-	local albums = {}
-	for album in result:gmatch("([^,]+)") do
-		album = album:match("^%s*(.-)%s*$")
-		table.insert(albums, album)
-	end
+
+	-- Convert table string into table
+	local result_chunk = "return " .. result
+	local albums = loadstring(result_chunk)()
 
 	local unique_albums = remove_duplicates(albums)
 
@@ -336,16 +331,15 @@ end
 ---Get a list of tracks from your Apple Music library
 ---@usage require('nvim-apple-music').get_tracks()
 M.get_tracks = function()
-	local command = [[osascript  -e 'tell application "Music" to get name of every track']]
+	local command = [[osascript  -e 'tell application "Music" to get name of every track' -s s]]
 	local handle = io.popen(command)
 	local result = handle:read("*a")
 	handle:close()
-	-- Split the result into a table of album names
-	local tracks = {}
-	for track in result:gmatch("([^,]+)") do
-		track = track:match("^%s*(.-)%s*$")
-		table.insert(tracks, track)
-	end
+
+	-- Convert table string into table
+	local result_chunk = "return " .. result
+	local tracks = loadstring(result_chunk)()
+
 	return tracks
 end
 


### PR DESCRIPTION
## Details

When we had track, album, or playlist items with a comma, the regex used for creating the table removed necessary parts of the string. This commit fixes this issue by using osascript's `-s` flag with a value `s` which returns a recompilable source form (for more details see `man osascript`). The new return value (it'll be in this format: `'{"song1", "song2", "song3"}'`) can then be converted into a table with `loadstring`.

## Example of  the issue and fix:

- Track's title in the list:

<img width="863" alt="Screenshot 2024-07-20 at 11 28 38" src="https://github.com/user-attachments/assets/06a6ec88-d1e3-4560-96b8-602e9dbcd1cf">


- Track's actual title:

<img width="509" alt="Screenshot 2024-07-20 at 11 28 50" src="https://github.com/user-attachments/assets/5ff25bdc-8d4b-42e3-80b1-90c3ed93069d">


- Track's title in the list after the fix:

<img width="823" alt="Screenshot 2024-07-20 at 11 31 32" src="https://github.com/user-attachments/assets/332eed86-ca52-4cec-9658-c6542f3b6d19">
