### PR TITLE
Feat: Change current track's favorited state

### DIFF
--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -192,6 +192,10 @@ end
 ---@usage require('apple-music').set_current_track_favorited(true)
 ---@usage require('apple-music').set_current_track_favorited(false)
 M.set_current_track_favorited = function(state)
+	local track = M.get_current_track()
+	if not track then
+		return
+	end
 	local command_property = "favorited"
 	-- Before version 14 (Sonoma) the property was called `loved`
 	if grab_os_version() < 14 then
@@ -202,12 +206,7 @@ M.set_current_track_favorited = function(state)
 		command_property,
 		state
 	)
-	local success = execute(command)
-	if not success then
-		print("Could not set current track as favorited")
-		return
-	end
-	local track = M.get_current_track()
+	execute(command)
 	if state then
 		print("Favorited track: '" .. track .. "'")
 	else
@@ -368,6 +367,10 @@ end
 M.get_current_track = function()
 	local command = [[osascript -e 'tell application "Music" to get {name, artist} of current track' -s s]]
 	local _, result = execute(command)
+	if result == "" then
+		print("Could not get current track")
+		return
+	end
 	local result_chunk = "return " .. result
 	local current_track = loadstring(result_chunk)()
 	return current_track[1] .. " - " .. current_track[2]

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -45,8 +45,8 @@ local execute = function(cmd)
 end
 
 local grab_os_version = function()
-	local cmd = [[ osascript -e 'set osver to system version of (system info)' ]]
-	local _, result = execute(cmd)
+	local command = [[ osascript -e 'set osver to system version of (system info)' ]]
+	local _, result = execute(command)
 	return tonumber(result)
 end
 
@@ -192,14 +192,14 @@ end
 ---@usage require('apple-music').set_current_track_favorited(true)
 ---@usage require('apple-music').set_current_track_favorited(false)
 M.set_current_track_favorited = function(state)
-  local cmd_property = "favorited"
+  local command_property = "favorited"
   if grab_os_version() < 14 then
-    cmd_property = "loved"
+    command_property = "loved"
   end
-	local command = string.format([[
+  local command = string.format([[
     osascript -e 'tell application "Music" to set %s of current track to "%s"'
-  ]], cmd_property, state)
-	local success = execute(command)
+  ]], command_property, state)
+  local success = execute(command)
   if not success then
     print("Could not set current track as favorited")
     return

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -192,24 +192,26 @@ end
 ---@usage require('apple-music').set_current_track_favorited(true)
 ---@usage require('apple-music').set_current_track_favorited(false)
 M.set_current_track_favorited = function(state)
-  local command_property = "favorited"
-  if grab_os_version() < 14 then
-    command_property = "loved"
-  end
-  local command = string.format([[
-    osascript -e 'tell application "Music" to set %s of current track to "%s"'
-  ]], command_property, state)
-  local success = execute(command)
-  if not success then
-    print("Could not set current track as favorited")
-    return
-  end
-  local track = M.get_current_track()
-  if state then
-    print("Favorited track: '" .. track .. "'")
-  else
-    print("Undid favorite for: '" .. track .. "'")
-  end
+	local command_property = "favorited"
+	if grab_os_version() < 14 then
+		command_property = "loved"
+	end
+	local command = string.format(
+		[[ osascript -e 'tell application "Music" to set %s of current track to "%s"' ]],
+		command_property,
+		state
+	)
+	local success = execute(command)
+	if not success then
+		print("Could not set current track as favorited")
+		return
+	end
+	local track = M.get_current_track()
+	if state then
+		print("Favorited track: '" .. track .. "'")
+	else
+		print("Undid favorite for: '" .. track .. "'")
+	end
 end
 
 ---Toggle shuffle
@@ -363,11 +365,11 @@ end
 ---Get the name and artist of the current track (in the following format: <name> - <author>).
 ---@usage require('apple-music').get_current_track()
 M.get_current_track = function()
-  local command = [[osascript -e 'tell application "Music" to get {name, artist} of current track' -s s]]
-  local _, result = execute(command)
+	local command = [[osascript -e 'tell application "Music" to get {name, artist} of current track' -s s]]
+	local _, result = execute(command)
 	local result_chunk = "return " .. result
 	local current_track = loadstring(result_chunk)()
-  return current_track[1] .. " - " .. current_track[2]
+	return current_track[1] .. " - " .. current_track[2]
 end
 
 ---Get a list of tracks from your Apple Music library

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -213,7 +213,7 @@ end
 ---NOTE: Below Sonoma it'll be loved.
 ---@usage require('apple-music').favorite_current_track()
 M.favorite_current_track = function()
-  local current_track = M.get_current_track()
+  local current_track = M.get_current_trackname()
   if not current_track then
     return
   end
@@ -224,7 +224,7 @@ end
 ---NOTE: Below Sonoma it'll be unloved.
 ---@usage require('apple-music').unfavorite_current_track()
 M.unfavorite_current_track = function()
-  local current_track = M.get_current_track()
+  local current_track = M.get_current_trackname()
   if not current_track then
     return
   end
@@ -380,8 +380,8 @@ M.select_album_telescope = function()
 end
 
 ---Get the name of the current track.
----@usage require('apple-music').get_current_track()
-M.get_current_track = function()
+---@usage require('apple-music').get_current_trackname()
+M.get_current_trackname = function()
   local command = [[osascript -e 'tell application "Music" to get {name} of current track']]
   local _, result = execute(command)
   if result == "" then

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -44,6 +44,12 @@ local execute = function(cmd)
 	return pcall(exe, cmd)
 end
 
+local grab_os_version = function()
+	local cmd = [[ osascript -e 'set osver to system version of (system info)' ]]
+	local _, result = execute(cmd)
+	return tonumber(result)
+end
+
 ---@mod apple-music.nvim PLUGIN OVERVIEW
 local M = {}
 

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -193,6 +193,7 @@ end
 ---@usage require('apple-music').set_current_track_favorited(false)
 M.set_current_track_favorited = function(state)
 	local command_property = "favorited"
+	-- Before version 14 (Sonoma) the property was called `loved`
 	if grab_os_version() < 14 then
 		command_property = "loved"
 	end

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -44,10 +44,12 @@ local execute = function(cmd)
 	return pcall(exe, cmd)
 end
 
-local grab_os_version = function()
-	local command = [[ osascript -e 'set osver to system version of (system info)' ]]
-	local _, result = execute(command)
-	return tonumber(result)
+local grab_major_os_version = function()
+  local command = [[ osascript -e 'set osver to system version of (system info)' ]]
+  local _, result = execute(command)
+  return tonumber(result:match("%d+"))
+end
+
 end
 
 ---@mod apple-music.nvim PLUGIN OVERVIEW

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -45,32 +45,32 @@ local execute = function(cmd)
 end
 
 local grab_major_os_version = function()
-  local command = [[ osascript -e 'set osver to system version of (system info)' ]]
-  local _, result = execute(command)
-  return tonumber(result:match("%d+"))
+	local command = [[ osascript -e 'set osver to system version of (system info)' ]]
+	local _, result = execute(command)
+	return tonumber(result:match("%d+"))
 end
 
 ---Change the favorited state of a track.
 ---@param track string
 ---@param state boolean
 local set_favorite_track_by_name = function(track, state)
-  local command_property = "favorited"
-  -- Before version 14 (Sonoma) the property was called `loved`
-  if grab_major_os_version() < 14 then
-    command_property = "loved"
-  end
-  local command = string.format(
-    [[ osascript -e 'tell application "Music" to set %s of track "%s" to "%s"' ]],
-    command_property,
-    track,
-    state
-  )
-  execute(command)
-  if state then
-    print("Favorited track: '" .. track .. "'")
-  else
-    print("Unfavorited track: '" .. track .. "'")
-  end
+	local command_property = "favorited"
+	-- Before version 14 (Sonoma) the property was called `loved`
+	if grab_major_os_version() < 14 then
+		command_property = "loved"
+	end
+	local command = string.format(
+		[[ osascript -e 'tell application "Music" to set %s of track "%s" to "%s"' ]],
+		command_property,
+		track,
+		state
+	)
+	execute(command)
+	if state then
+		print("Favorited track: '" .. track .. "'")
+	else
+		print("Unfavorited track: '" .. track .. "'")
+	end
 end
 
 ---@mod apple-music.nvim PLUGIN OVERVIEW
@@ -213,22 +213,22 @@ end
 ---NOTE: Below Sonoma it'll be loved.
 ---@usage require('apple-music').favorite_current_track()
 M.favorite_current_track = function()
-  local current_track = M.get_current_trackname()
-  if not current_track then
-    return
-  end
-  set_favorite_track_by_name(current_track, true)
+	local current_track = M.get_current_trackname()
+	if not current_track then
+		return
+	end
+	set_favorite_track_by_name(current_track, true)
 end
 
 ---Unfavorite current track.
 ---NOTE: Below Sonoma it'll be unloved.
 ---@usage require('apple-music').unfavorite_current_track()
 M.unfavorite_current_track = function()
-  local current_track = M.get_current_trackname()
-  if not current_track then
-    return
-  end
-  set_favorite_track_by_name(current_track, false)
+	local current_track = M.get_current_trackname()
+	if not current_track then
+		return
+	end
+	set_favorite_track_by_name(current_track, false)
 end
 
 ---Toggle shuffle
@@ -382,13 +382,13 @@ end
 ---Get the name of the current track.
 ---@usage require('apple-music').get_current_trackname()
 M.get_current_trackname = function()
-  local command = [[osascript -e 'tell application "Music" to get {name} of current track']]
-  local _, result = execute(command)
-  if result == "" then
-    print("Could not get current track")
-    return
-  end
-  return vim.trim(result)
+	local command = [[osascript -e 'tell application "Music" to get {name} of current track']]
+	local _, result = execute(command)
+	if result == "" then
+		print("Could not get current track")
+		return
+	end
+	return vim.trim(result)
 end
 
 ---Get a list of tracks from your Apple Music library

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -362,18 +362,16 @@ M.select_album_telescope = function()
 	}):find()
 end
 
----Get the name and artist of the current track (in the following format: <name> - <author>).
+---Get the name of the current track.
 ---@usage require('apple-music').get_current_track()
 M.get_current_track = function()
-	local command = [[osascript -e 'tell application "Music" to get {name, artist} of current track' -s s]]
-	local _, result = execute(command)
-	if result == "" then
-		print("Could not get current track")
-		return
-	end
-	local result_chunk = "return " .. result
-	local current_track = loadstring(result_chunk)()
-	return current_track[1] .. " - " .. current_track[2]
+  local command = [[osascript -e 'tell application "Music" to get {name} of current track']]
+  local _, result = execute(command)
+  if result == "" then
+    print("Could not get current track")
+    return
+  end
+  return result
 end
 
 ---Get a list of tracks from your Apple Music library

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -350,6 +350,16 @@ M.select_album_telescope = function()
 	}):find()
 end
 
+---Get the name and artist of the current track (in the following format: <name> - <author>).
+---@usage require('apple-music').get_current_track()
+M.get_current_track = function()
+  local command = [[osascript -e 'tell application "Music" to get {name, artist} of current track' -s s]]
+  local _, result = execute(command)
+	local result_chunk = "return " .. result
+	local current_track = loadstring(result_chunk)()
+  return current_track[1] .. " - " .. current_track[2]
+end
+
 ---Get a list of tracks from your Apple Music library
 ---@usage require('apple-music').get_tracks()
 M.get_tracks = function()

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -50,7 +50,18 @@ local grab_major_os_version = function()
 	return tonumber(result:match("%d+"))
 end
 
----Change the favorited state of a track.
+---Get the name of the current (playing) track.
+local get_current_trackname = function()
+	local command = [[osascript -e 'tell application "Music" to get name of current track']]
+	local _, result = execute(command)
+	if result == "" then
+		print("Could not get current track")
+		return
+	end
+	return vim.trim(result)
+end
+
+---Set the favorited/loved state of a track.
 ---@param track string
 ---@param state boolean
 local set_track_favorited_state = function(track, state)
@@ -209,22 +220,22 @@ M.disable_shuffle = function()
 	end
 end
 
----Favorite current track.
----NOTE: Below Sonoma it'll be loved.
+---Favorite current (playing) track.
+---NOTE: Below macOS 14 (Sonoma), it'll be `loved`.
 ---@usage require('apple-music').favorite_current_track()
 M.favorite_current_track = function()
-	local current_track = M.get_current_trackname()
+	local current_track = get_current_trackname()
 	if not current_track then
 		return
 	end
 	set_track_favorited_state(current_track, true)
 end
 
----Unfavorite current track.
----NOTE: Below Sonoma it'll be unloved.
+---Unfavorite current (playing) track.
+---NOTE: Below macOS 14 (Sonoma), it'll be un-`loved`.
 ---@usage require('apple-music').unfavorite_current_track()
 M.unfavorite_current_track = function()
-	local current_track = M.get_current_trackname()
+	local current_track = get_current_trackname()
 	if not current_track then
 		return
 	end
@@ -377,18 +388,6 @@ M.select_album_telescope = function()
 			return true
 		end,
 	}):find()
-end
-
----Get the name of the current track.
----@usage require('apple-music').get_current_trackname()
-M.get_current_trackname = function()
-	local command = [[osascript -e 'tell application "Music" to get {name} of current track']]
-	local _, result = execute(command)
-	if result == "" then
-		print("Could not get current track")
-		return
-	end
-	return vim.trim(result)
 end
 
 ---Get a list of tracks from your Apple Music library

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -199,7 +199,17 @@ M.set_current_track_favorited = function(state)
 	local command = string.format([[
     osascript -e 'tell application "Music" to set %s of current track to "%s"'
   ]], cmd_property, state)
-	execute(command)
+	local success = execute(command)
+  if not success then
+    print("Could not set current track as favorited")
+    return
+  end
+  local track = M.get_current_track()
+  if state then
+    print("Favorited track: '" .. track .. "'")
+  else
+    print("Undid favorite for: '" .. track .. "'")
+  end
 end
 
 ---Toggle shuffle

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -186,6 +186,22 @@ M.disable_shuffle = function()
 	end
 end
 
+---Change the favorited state of the current music.
+---It also handles Mac OS versions below 14 (Sonoma) where it used to be called "loved".
+---@param state boolean: The state of favorited to be set for current track.
+---@usage require('apple-music').set_current_track_favorited(true)
+---@usage require('apple-music').set_current_track_favorited(false)
+M.set_current_track_favorited = function(state)
+  local cmd_property = "favorited"
+  if grab_os_version() < 14 then
+    cmd_property = "loved"
+  end
+	local command = string.format([[
+    osascript -e 'tell application "Music" to set %s of current track to "%s"'
+  ]], cmd_property, state)
+	execute(command)
+end
+
 ---Toggle shuffle
 ---@usage require('apple-music').toggle_shuffle()
 M.toggle_shuffle = function()

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -53,7 +53,7 @@ end
 ---Change the favorited state of a track.
 ---@param track string
 ---@param state boolean
-local set_favorite_track_by_name = function(track, state)
+local set_track_favorited_state = function(track, state)
 	local command_property = "favorited"
 	-- Before version 14 (Sonoma) the property was called `loved`
 	if grab_major_os_version() < 14 then
@@ -217,7 +217,7 @@ M.favorite_current_track = function()
 	if not current_track then
 		return
 	end
-	set_favorite_track_by_name(current_track, true)
+	set_track_favorited_state(current_track, true)
 end
 
 ---Unfavorite current track.
@@ -228,7 +228,7 @@ M.unfavorite_current_track = function()
 	if not current_track then
 		return
 	end
-	set_favorite_track_by_name(current_track, false)
+	set_track_favorited_state(current_track, false)
 end
 
 ---Toggle shuffle


### PR DESCRIPTION
With the included changes we'll be able to mark a track as favorited or undo this via the following examples:

- Favorite: `require('apple-music').set_current_track_favorited(true)`
- Undo favorite: `require('apple-music').set_current_track_favorited(false)`

This command will also handle if the OS version is below 14 (Sonoma) where the `favorited` property was called `loved`. This is done via the `osascript` that @p5quared provided in the related [issue](https://github.com/p5quared/apple-music.nvim/issues/10)'s comment.

If the command succeeds it will prompt the change and the name plus the author of the track it was applied for.

With these changes, we're now also able to get the current track with `require('apple-music').get_current_track()` and it will return the name and author of the track in the following format `<name> - <author>`.