### PR TITLE
feat: auto cleanup temporary playlists

### DIFF
--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -114,6 +114,11 @@ local M = {}
 --- 								(see `apple-music.caveats` for details on temporary playlists)
 M.setup = function(opts)
 	M.temp_playlist_name = opts.temp_playlist_name or "apple-music.nvim"
+	vim.api.nvim_create_autocmd("VimLeave", {
+		callback = function()
+			M.cleanup_all()
+		end
+	})
 end
 
 ---Play a track by title


### PR DESCRIPTION
This PR adds an autocmd which deletes temporary playlists on `VimLeave`. 
Thanks to @Ren-B-7 for suggesting this and providing an implementation! :heart:

This PR closes #35.

## Summary by Sourcery

New Features:
- Introduce an autocmd to automatically delete temporary playlists on 'VimLeave'.