### PR TITLE
[feat] Lualine compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ To play a specific track, you can use the following command in Neovim:
 
 To open the Telescope picker and select a playlist to play:
 
-````vim
+```vim
 :lua require('apple-music').select_playlist_telescope()
+```
 
 ### Example (lualine)
 
@@ -84,7 +85,7 @@ require('lualine').setup {
     }
   }
 }
-````
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,24 @@ To play a specific track, you can use the following command in Neovim:
 
 To open the Telescope picker and select a playlist to play:
 
-```vim
+````vim
 :lua require('apple-music').select_playlist_telescope()
-```
+
+### Example (lualine)
+
+This example demonstrates how to integrate with lualine.
+Other statusline plugins can be used as well, and the process should be similar.
+Refer to the documentation of your statusline plugin for more information.
+
+```lua
+require('lualine').setup {
+  sections = {
+    lualine_x = {
+      require("apple-music")._current_track,
+    }
+  }
+}
+````
 
 ## License
 
@@ -84,8 +99,8 @@ Before opening pull requests, please run `stylua` locally.
 
 - [nvim-telescope/telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
 - [mcthomas/Apple-Music-CLI-Player](https://github.com/mcthomas/Apple-Music-CLI-Player)
-    - Much of the Apple Script was taken/heavily inspired from this repo.
+  - Much of the Apple Script was taken/heavily inspired from this repo.
     I probably could have pieced together a lot of the basic stuff, but probably
     not the workaround for playing albums with temporary playlists...
 - [Temporary Playlist Workaround](https://discussions.apple.com/thread/1053355?sortBy=best)
-    - Well that temp playlist workaround from mcthomas was actually from here.
+  - Well that temp playlist workaround from mcthomas was actually from here.

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -55,6 +55,16 @@ local grab_major_os_version = function()
 	return tonumber(result:match("%d+"))
 end
 
+---Get the name of the current (playing) track.
+local get_current_trackname = function()
+	local command = [[osascript -e 'tell application "Music" to get name of current track']]
+	local _, result = execute(command)
+	if result == "" then
+		return
+	end
+	return vim.trim(result)
+end
+
 ---Returns whether the provided track is favorited/loved.
 ---@param track string
 local get_favorited_state_of_track = function(track)
@@ -92,16 +102,6 @@ local set_track_favorited_state = function(track, state)
 	else
 		print("Unfavorited track: '" .. track .. "'")
 	end
-end
-
----Get the name of the current (playing) track.
-local get_current_trackname = function()
-	local command = [[osascript -e 'tell application "Music" to get name of current track']]
-	local _, result = execute(command)
-	if result == "" then
-		return
-	end
-	return vim.trim(result)
 end
 
 ---@mod apple-music.nvim PLUGIN OVERVIEW
@@ -271,7 +271,7 @@ end
 ---NOTE: Below macOS 14 (Sonoma), it'll be `loved`.
 ---@usage require('apple-music').favorite_current_track()
 M.favorite_current_track = function()
-	local current_track = M.set_current_trackname()
+	local current_track = get_current_trackname()
 	if not current_track then
 		return
 	end

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -55,17 +55,6 @@ local grab_major_os_version = function()
 	return tonumber(result:match("%d+"))
 end
 
----Get the name of the current (playing) track.
-local get_current_trackname = function()
-	local command = [[osascript -e 'tell application "Music" to get name of current track']]
-	local _, result = execute(command)
-	if result == "" then
-		print("Could not get current track")
-		return
-	end
-	return vim.trim(result)
-end
-
 ---Returns whether the provided track is favorited/loved.
 ---@param track string
 local get_favorited_state_of_track = function(track)
@@ -122,6 +111,17 @@ M.setup = function(opts)
 			M.cleanup_all()
 		end,
 	})
+end
+
+---Get the name of the current (playing) track.
+M._get_current_trackname = function()
+	local command = [[osascript -e 'tell application "Music" to get name of current track']]
+	local _, result = execute(command)
+	if result == "" then
+		print("Could not get current track")
+		return
+	end
+	return vim.trim(result)
 end
 
 ---Play a track by title
@@ -268,7 +268,7 @@ end
 ---NOTE: Below macOS 14 (Sonoma), it'll be `loved`.
 ---@usage require('apple-music').favorite_current_track()
 M.favorite_current_track = function()
-	local current_track = get_current_trackname()
+	local current_track = M.set_current_trackname()
 	if not current_track then
 		return
 	end
@@ -279,7 +279,7 @@ end
 ---NOTE: Below macOS 14 (Sonoma), it'll be un-`loved`.
 ---@usage require('apple-music').unfavorite_current_track()
 M.unfavorite_current_track = function()
-	local current_track = get_current_trackname()
+	local current_track = M._get_current_trackname()
 	if not current_track then
 		return
 	end
@@ -290,7 +290,7 @@ end
 ---NOTE: Below macOS 14 (Sonoma), it'll toggle `loved`.
 ---@usage require('apple-music').toggle_favorite_current_track()
 M.toggle_favorite_current_track = function()
-	local current_track = get_current_trackname()
+	local current_track = M._get_current_trackname()
 	if not current_track then
 		return
 	end

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -96,6 +96,9 @@ end
 
 ---@mod apple-music.nvim PLUGIN OVERVIEW
 local M = {}
+local last_track = "No track playing"
+local last_update = 0
+local update_interval = 5 -- Update every 5 seconds
 
 ---Setup the plugin
 ---@param opts table|nil: Optional configuration for the plugin
@@ -115,13 +118,18 @@ end
 
 ---Get the name of the current (playing) track.
 M._get_current_trackname = function()
-	local command = [[osascript -e 'tell application "Music" to get name of current track']]
-	local _, result = execute(command)
-	if result == "" then
-		print("Could not get current track")
-		return
+	local current_time = os.time()
+	if current_time - last_update >= update_interval then
+		local command = [[osascript -e 'tell application "Music" to get name of current track']]
+		local _, result = execute(command)
+		if result == "" then
+			last_track = "No track playing"
+		else
+			last_track = vim.trim(result)
+		end
+		last_update = current_time
 	end
-	return vim.trim(result)
+	return last_track
 end
 
 ---Play a track by title

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -107,6 +107,7 @@ end
 
 ---@mod apple-music.nvim PLUGIN OVERVIEW
 local M = {}
+M._current_track = "No Track Playing"
 
 ---Setup the plugin
 ---@param opts table|nil: Optional configuration for the plugin
@@ -122,10 +123,6 @@ M.setup = function(opts)
 			M.cleanup_all()
 		end,
 	})
-end
-
-M._current_track = function()
-	return get_current_trackname()
 end
 
 ---Play a track by title

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -60,6 +60,7 @@ local get_current_trackname = function()
 	local command = [[osascript -e 'tell application "Music" to get name of current track']]
 	local _, result = execute(command)
 	if result == "" then
+		print("Could not get current track")
 		return
 	end
 	return vim.trim(result)

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -96,9 +96,6 @@ end
 
 ---@mod apple-music.nvim PLUGIN OVERVIEW
 local M = {}
-local last_track = "No track playing"
-local last_update = 0
-local update_interval = 5 -- Update every 5 seconds
 
 ---Setup the plugin
 ---@param opts table|nil: Optional configuration for the plugin
@@ -118,18 +115,13 @@ end
 
 ---Get the name of the current (playing) track.
 M._get_current_trackname = function()
-	local current_time = os.time()
-	if current_time - last_update >= update_interval then
-		local command = [[osascript -e 'tell application "Music" to get name of current track']]
-		local _, result = execute(command)
-		if result == "" then
-			last_track = "No track playing"
-		else
-			last_track = vim.trim(result)
-		end
-		last_update = current_time
+	local command = [[osascript -e 'tell application "Music" to get name of current track']]
+	local _, result = execute(command)
+	if result == "" then
+		print("Could not get current track")
+		return
 	end
-	return last_track
+	return vim.trim(result)
 end
 
 ---Play a track by title

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -99,7 +99,6 @@ local get_current_trackname = function()
 	local command = [[osascript -e 'tell application "Music" to get name of current track']]
 	local _, result = execute(command)
 	if result == "" then
-		print("Could not get current track")
 		return
 	end
 	return vim.trim(result)
@@ -107,7 +106,9 @@ end
 
 ---@mod apple-music.nvim PLUGIN OVERVIEW
 local M = {}
-M._current_track = "No Track Playing"
+M._current_track = function()
+	return get_current_trackname()
+end
 
 ---Setup the plugin
 ---@param opts table|nil: Optional configuration for the plugin

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -94,6 +94,17 @@ local set_track_favorited_state = function(track, state)
 	end
 end
 
+---Get the name of the current (playing) track.
+local get_current_trackname = function()
+	local command = [[osascript -e 'tell application "Music" to get name of current track']]
+	local _, result = execute(command)
+	if result == "" then
+		print("Could not get current track")
+		return
+	end
+	return vim.trim(result)
+end
+
 ---@mod apple-music.nvim PLUGIN OVERVIEW
 local M = {}
 
@@ -113,15 +124,8 @@ M.setup = function(opts)
 	})
 end
 
----Get the name of the current (playing) track.
-M._get_current_trackname = function()
-	local command = [[osascript -e 'tell application "Music" to get name of current track']]
-	local _, result = execute(command)
-	if result == "" then
-		print("Could not get current track")
-		return
-	end
-	return vim.trim(result)
+M._current_track = function()
+	return get_current_trackname()
 end
 
 ---Play a track by title
@@ -129,6 +133,7 @@ end
 ---@usage require('apple-music').play_track("Sir Duke")
 M.play_track = function(track)
 	print("Playing " .. track)
+	M._current_track = track
 
 	local sanitized = sanitize_name(track)
 	local command = string.format(
@@ -161,6 +166,7 @@ M.play_playlist = function(playlist)
 	)
 
 	execute(cmd)
+	M._current_track = get_current_trackname()
 end
 
 ---Play an album by name
@@ -188,6 +194,7 @@ M.play_album = function(album)
 	)
 
 	execute(command)
+	M._current_track = get_current_trackname()
 end
 
 ---Play the next track
@@ -279,7 +286,7 @@ end
 ---NOTE: Below macOS 14 (Sonoma), it'll be un-`loved`.
 ---@usage require('apple-music').unfavorite_current_track()
 M.unfavorite_current_track = function()
-	local current_track = M._get_current_trackname()
+	local current_track = get_current_trackname()
 	if not current_track then
 		return
 	end
@@ -290,7 +297,7 @@ end
 ---NOTE: Below macOS 14 (Sonoma), it'll toggle `loved`.
 ---@usage require('apple-music').toggle_favorite_current_track()
 M.toggle_favorite_current_track = function()
-	local current_track = M._get_current_trackname()
+	local current_track = get_current_trackname()
 	if not current_track then
 		return
 	end

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -106,9 +106,7 @@ end
 
 ---@mod apple-music.nvim PLUGIN OVERVIEW
 local M = {}
-M._current_track = function()
-	return get_current_trackname()
-end
+M._current_track = "No Track Playing"
 
 ---Setup the plugin
 ---@param opts table|nil: Optional configuration for the plugin


### PR DESCRIPTION
You can see the track name in Lualine

## Summary by Sourcery

Introduce compatibility with Lualine to display the current track name in the status line and update the documentation with integration instructions.

New Features:
- Add Lualine compatibility to display the current track name in the status line.

Documentation:
- Update README with an example of integrating the plugin with Lualine.