### PR TITLE
feat: make telescope optional

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.lua]
+indent_style = tab

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This Neovim plugin allows you to control Apple Music directly from within Neovim
 - Play specific tracks, playlists, or albums.
 - Control playback (play, pause, next track, previous track, toggle play/pause).
 - Enable or disable shuffle.
-- View and select entries using Telescope picker.
+- View and select entries using Telescope picker. (if you don't have Telescope installed, `vim.ui.select` is used instead)
 
 ## Installation
 
@@ -20,14 +20,15 @@ Here is how I have this plugin setup, minus the dev stuff.
 ```lua
 {
     'p5quared/apple-music.nvim',
-    dependencies = { 'nvim-telescope/telescope.nvim' },
+    -- Optional dependencies
+    -- dependencies = { 'nvim-telescope/telescope.nvim' },
     config = true,
     keys = {
         { "<leader>amp", function() require("apple-music").toggle_play() end,               desc = "Toggle [P]layback" },
         { "<leader>ams", function() require("apple-music").toggle_shuffle() end,            desc = "Toggle [S]huffle" },
-        { "<leader>fp",  function() require("apple-music").select_playlist_telescope() end, desc = "[F]ind [P]laylists" },
-        { "<leader>fa",  function() require("apple-music").select_album_telescope() end,    desc = "[F]ind [A]lbum" },
-        { "<leader>fs",  function() require("apple-music").select_track_telescope() end,    desc = "[F]ind [S]ong" },
+        { "<leader>fp",  function() require("apple-music").select_playlist() end,           desc = "[F]ind [P]laylists" },
+        { "<leader>fa",  function() require("apple-music").select_album() end,              desc = "[F]ind [A]lbum" },
+        { "<leader>fs",  function() require("apple-music").select_track() end,              desc = "[F]ind [S]ong" },
         { "<leader>amx", function() require("apple-music").cleanup_all() end,               desc = "Cleanup Temp Playlists" },
     },
 }
@@ -65,10 +66,10 @@ To play a specific track, you can use the following command in Neovim:
 :lua require('apple-music').play_track("Bohemian Rhapsody")
 ```
 
-To open the Telescope picker and select a playlist to play:
+To open the picker and select a playlist to play:
 
 ```vim
-:lua require('apple-music').select_playlist_telescope()
+:lua require('apple-music').select_playlist()
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This Neovim plugin allows you to control Apple Music directly from within Neovim
 - Play specific tracks, playlists, or albums.
 - Control playback (play, pause, next track, previous track, toggle play/pause).
 - Enable or disable shuffle.
-- View and select entries using Telescope picker. (if you don't have Telescope installed, `vim.ui.select` is used instead)
+- View and select entries using a picker. (if you don't have Telescope installed, `vim.ui.select` is used instead)
 
 ## Installation
 

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -137,7 +137,7 @@ M.play_track = function(track)
 		sanitized
 	)
 
-	local result = execute(command)
+	local _ = execute(command)
 end
 
 ---Play a playlist by name
@@ -332,7 +332,7 @@ M._cleanup = function()
 	)
 
 	local handle = io.popen(cmd)
-	local result = handle:read("*a")
+	local _ = handle:read("*a")
 	handle:close()
 end
 

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -13,92 +13,92 @@
 local picker = require("apple-music.picker")
 
 local function execute_applescript(script)
-  local command = "osascript -e '" .. script .. "'"
-  local handle = io.popen(command)
-  local result = handle:read("*a")
-  handle:close()
-  return result
+	local command = "osascript -e '" .. script .. "'"
+	local handle = io.popen(command)
+	local result = handle:read("*a")
+	handle:close()
+	return result
 end
 
 local am_run = function(cmd)
-  local script = 'tell application "Music" to ' .. cmd
-  return execute_applescript(script)
+	local script = 'tell application "Music" to ' .. cmd
+	return execute_applescript(script)
 end
 
 local am_app_run = function(cmd)
-  local script = 'tell app "Music" to ' .. cmd
-  return execute_applescript(script)
+	local script = 'tell app "Music" to ' .. cmd
+	return execute_applescript(script)
 end
 
 local execute = function(cmd)
-  local exe = function(cmd)
-    local handle = io.popen(cmd)
-    local result = handle:read("*a")
-    handle:close()
-    return result
-  end
-  return pcall(exe, cmd)
+	local exe = function(cmd)
+		local handle = io.popen(cmd)
+		local result = handle:read("*a")
+		handle:close()
+		return result
+	end
+	return pcall(exe, cmd)
 end
 
 --- Escape single and double quotes from names
 local sanitize_name = function(name)
-  return name:gsub("\\", "\\\\"):gsub("'", "'\\''"):gsub('"', '\\"')
+	return name:gsub("\\", "\\\\"):gsub("'", "'\\''"):gsub('"', '\\"')
 end
 
 local grab_major_os_version = function()
-  local command = [[ osascript -e 'set osver to system version of (system info)' ]]
-  local _, result = execute(command)
-  return tonumber(result:match("%d+"))
+	local command = [[ osascript -e 'set osver to system version of (system info)' ]]
+	local _, result = execute(command)
+	return tonumber(result:match("%d+"))
 end
 
 ---Get the name of the current (playing) track.
 local get_current_trackname = function()
-  local command = [[osascript -e 'tell application "Music" to get name of current track']]
-  local _, result = execute(command)
-  if result == "" then
-    print("Could not get current track")
-    return
-  end
-  return vim.trim(result)
+	local command = [[osascript -e 'tell application "Music" to get name of current track']]
+	local _, result = execute(command)
+	if result == "" then
+		print("Could not get current track")
+		return
+	end
+	return vim.trim(result)
 end
 
 ---Returns whether the provided track is favorited/loved.
 ---@param track string
 local get_favorited_state_of_track = function(track)
-  local command_property = "favorited"
-  -- Before version 14 (Sonoma) the property was called `loved`
-  if grab_major_os_version() < 14 then
-    command_property = "loved"
-  end
-  local command =
-      string.format([[osascript -e 'tell application "Music" to get %s of track "%s"']], command_property, track)
-  local _, result = execute(command)
-  return vim.trim(result) == "true"
+	local command_property = "favorited"
+	-- Before version 14 (Sonoma) the property was called `loved`
+	if grab_major_os_version() < 14 then
+		command_property = "loved"
+	end
+	local command =
+			string.format([[osascript -e 'tell application "Music" to get %s of track "%s"']], command_property, track)
+	local _, result = execute(command)
+	return vim.trim(result) == "true"
 end
 
 ---Set the favorited/loved state of a track.
 ---@param track string
 ---@param state boolean
 local set_track_favorited_state = function(track, state)
-  local command_property = "favorited"
-  -- Before version 14 (Sonoma) the property was called `loved`
-  if grab_major_os_version() < 14 then
-    command_property = "loved"
-  end
+	local command_property = "favorited"
+	-- Before version 14 (Sonoma) the property was called `loved`
+	if grab_major_os_version() < 14 then
+		command_property = "loved"
+	end
 
-  local sanitized_trackname = sanitize_name(track)
-  local command = string.format(
-    [[ osascript -e 'tell application "Music" to set %s of track "%s" to "%s"' ]],
-    command_property,
-    sanitized_trackname,
-    state
-  )
-  execute(command)
-  if state then
-    print("Favorited track: '" .. track .. "'")
-  else
-    print("Unfavorited track: '" .. track .. "'")
-  end
+	local sanitized_trackname = sanitize_name(track)
+	local command = string.format(
+		[[ osascript -e 'tell application "Music" to set %s of track "%s" to "%s"' ]],
+		command_property,
+		sanitized_trackname,
+		state
+	)
+	execute(command)
+	if state then
+		print("Favorited track: '" .. track .. "'")
+	else
+		print("Unfavorited track: '" .. track .. "'")
+	end
 end
 
 ---@mod apple-music.nvim PLUGIN OVERVIEW
@@ -109,54 +109,54 @@ local M = {}
 --- * {temp_playlist_name: string} - The name of the temporary playlist to use
 --- 								(see `apple-music.caveats` for details on temporary playlists)
 M.setup = function(opts)
-  M.temp_playlist_name = opts.temp_playlist_name or "apple-music.nvim"
+	M.temp_playlist_name = opts.temp_playlist_name or "apple-music.nvim"
 
-  -- Cleanup temporary playlists on exit
-  -- TODO: Possible improvements by wrapping in pcall
-  vim.api.nvim_create_autocmd("VimLeave", {
-    callback = function()
-      M.cleanup_all()
-    end,
-  })
+	-- Cleanup temporary playlists on exit
+	-- TODO: Possible improvements by wrapping in pcall
+	vim.api.nvim_create_autocmd("VimLeave", {
+		callback = function()
+			M.cleanup_all()
+		end,
+	})
 end
 
 ---Play a track by title
 ---@param track string: The title of the track to play
 ---@usage require('apple-music').play_track("Sir Duke")
 M.play_track = function(track)
-  print("Playing " .. track)
+	print("Playing " .. track)
 
-  local sanitized = sanitize_name(track)
-  local command = string.format(
-    [[
+	local sanitized = sanitize_name(track)
+	local command = string.format(
+		[[
         osascript -e '
         tell application "Music"
             play track "%s"
         end tell'
     ]],
-    sanitized
-  )
+		sanitized
+	)
 
-  local result = execute(command)
+	local result = execute(command)
 end
 
 ---Play a playlist by name
 ---@param playlist string: The name of the playlist to play
 ---@usage require('apple-music').play_playlist("Slow Dance")
 M.play_playlist = function(playlist)
-  print("Playing playlist: " .. playlist)
+	print("Playing playlist: " .. playlist)
 
-  local sanitized = sanitize_name(playlist)
-  local cmd = string.format(
-    [[
+	local sanitized = sanitize_name(playlist)
+	local cmd = string.format(
+		[[
 		osascript -e '
 			tell application "Music" to play playlist "%s"
 		end'
 	]],
-    sanitized
-  )
+		sanitized
+	)
 
-  execute(cmd)
+	execute(cmd)
 end
 
 ---Play an album by name
@@ -164,11 +164,11 @@ end
 ---@param album string: The name of the album to play
 ---@usage require('apple-music').play_album("Nashville Skyline")
 M.play_album = function(album)
-  print("Playing album: " .. album)
+	print("Playing album: " .. album)
 
-  local sanitized = sanitize_name(album)
-  local command = string.format(
-    [[
+	local sanitized = sanitize_name(album)
+	local command = string.format(
+		[[
         osascript -e '
         tell application "Music"
             set tempPlaylist to make new playlist with properties {name:"%s"}
@@ -179,147 +179,147 @@ M.play_album = function(album)
             play tempPlaylist
         end tell'
     ]],
-    M.temp_playlist_name,
-    sanitized
-  )
+		M.temp_playlist_name,
+		sanitized
+	)
 
-  execute(command)
+	execute(command)
 end
 
 ---Play the next track
 ---@usage require('apple-music').next_track()
 M.next_track = function()
-  am_app_run("play next track")
-  print("Apple Music: Next Track")
+	am_app_run("play next track")
+	print("Apple Music: Next Track")
 end
 
 ---Play the previous track
 ---@usage require('apple-music').previous_track()
 M.previous_track = function()
-  am_run("previous track")
-  print("Apple Music: Previous Track")
+	am_run("previous track")
+	print("Apple Music: Previous Track")
 end
 
 ---Restart the current track
 ---@usage require('apple-music').restart_track()
 M.restart_track = function()
-  am_run("set player position to 0")
-  print("Apple Music: Restarted Track")
+	am_run("set player position to 0")
+	print("Apple Music: Restarted Track")
 end
 
 ---Toggle playback (play/pause)
 ---@usage require('apple-music').toggle_play()
 M.toggle_play = function()
-  am_run("playpause")
-  print("Apple Music: Toggled Playback")
+	am_run("playpause")
+	print("Apple Music: Toggled Playback")
 end
 
 ---Resume playback
 ---@usage require('apple-music').resume()
 M.resume = function()
-  am_run("play")
-  print("Apple Music: Resumed")
+	am_run("play")
+	print("Apple Music: Resumed")
 end
 
 ---Puase Playback
 ---@usage require('apple-music').pause()
 M.pause = function()
-  am_run("pause")
-  print("Apple Music: Paused")
+	am_run("pause")
+	print("Apple Music: Paused")
 end
 
 ---Enable shuffle
 ---@usage require('apple-music').enable_shuffle()
 M.enable_shuffle = function()
-  local cmd = [[ osascript -e 'tell application "Music" to set shuffle enabled to true']]
+	local cmd = [[ osascript -e 'tell application "Music" to set shuffle enabled to true']]
 
-  local handle = io.popen(cmd)
-  local result = handle:read("*a")
-  handle:close()
+	local handle = io.popen(cmd)
+	local result = handle:read("*a")
+	handle:close()
 
-  if result then
-    print("Apple Music: Shuffle enabled")
-  else
-    print("Apple Music: Failed to enable shuffle")
-  end
+	if result then
+		print("Apple Music: Shuffle enabled")
+	else
+		print("Apple Music: Failed to enable shuffle")
+	end
 end
 
 ---Disable shuffle
 ---@usage require('apple-music').disable_shuffle()
 M.disable_shuffle = function()
-  local cmd = [[ osascript -e 'tell application "Music" to set shuffle enabled to false']]
+	local cmd = [[ osascript -e 'tell application "Music" to set shuffle enabled to false']]
 
-  local handle = io.popen(cmd)
-  local result = handle:read("*a")
-  handle:close()
+	local handle = io.popen(cmd)
+	local result = handle:read("*a")
+	handle:close()
 
-  if result then
-    print("Apple Music: Shuffle disabled")
-  else
-    print("Apple Music: Failed to disable shuffle")
-  end
+	if result then
+		print("Apple Music: Shuffle disabled")
+	else
+		print("Apple Music: Failed to disable shuffle")
+	end
 end
 
 ---Favorite current (playing) track.
 ---NOTE: Below macOS 14 (Sonoma), it'll be `loved`.
 ---@usage require('apple-music').favorite_current_track()
 M.favorite_current_track = function()
-  local current_track = get_current_trackname()
-  if not current_track then
-    return
-  end
-  set_track_favorited_state(current_track, true)
+	local current_track = get_current_trackname()
+	if not current_track then
+		return
+	end
+	set_track_favorited_state(current_track, true)
 end
 
 ---Unfavorite current (playing) track.
 ---NOTE: Below macOS 14 (Sonoma), it'll be un-`loved`.
 ---@usage require('apple-music').unfavorite_current_track()
 M.unfavorite_current_track = function()
-  local current_track = get_current_trackname()
-  if not current_track then
-    return
-  end
-  set_track_favorited_state(current_track, false)
+	local current_track = get_current_trackname()
+	if not current_track then
+		return
+	end
+	set_track_favorited_state(current_track, false)
 end
 
 ---Toggle favorite for current (playing) track.
 ---NOTE: Below macOS 14 (Sonoma), it'll toggle `loved`.
 ---@usage require('apple-music').toggle_favorite_current_track()
 M.toggle_favorite_current_track = function()
-  local current_track = get_current_trackname()
-  if not current_track then
-    return
-  end
-  local is_favorited = get_favorited_state_of_track(current_track)
-  set_track_favorited_state(current_track, not is_favorited)
+	local current_track = get_current_trackname()
+	if not current_track then
+		return
+	end
+	local is_favorited = get_favorited_state_of_track(current_track)
+	set_track_favorited_state(current_track, not is_favorited)
 end
 
 ---Toggle shuffle
 ---@usage require('apple-music').toggle_shuffle()
 M.toggle_shuffle = function()
-  if M.shuffle_is_enabled() then
-    M.disable_shuffle()
-    print("Apple Music: Shuffle disabled")
-  else
-    M.enable_shuffle()
-    print("Apple Music: Shuffle enabled")
-  end
+	if M.shuffle_is_enabled() then
+		M.disable_shuffle()
+		print("Apple Music: Shuffle disabled")
+	else
+		M.enable_shuffle()
+		print("Apple Music: Shuffle enabled")
+	end
 end
 
 ---Determine if shuffle is enabled
 ---@usage require('apple-music').shuffle_is_enabled()
 M.shuffle_is_enabled = function()
-  local cmd = [[osascript -e 'tell application "Music" to get shuffle enabled']]
-  local handle = io.popen(cmd)
-  local result = handle:read("*a")
-  handle:close()
-  local is_enabled = result:match("true") and true or false
-  return is_enabled
+	local cmd = [[osascript -e 'tell application "Music" to get shuffle enabled']]
+	local handle = io.popen(cmd)
+	local result = handle:read("*a")
+	handle:close()
+	local is_enabled = result:match("true") and true or false
+	return is_enabled
 end
 
 M._cleanup = function()
-  local cmd = string.format(
-    [[
+	local cmd = string.format(
+		[[
 		osascript -e '
 		tell application "Music"
 			if (exists playlist "%s") then
@@ -327,21 +327,21 @@ M._cleanup = function()
 			end if
 		end tell'
 		]],
-    M.temp_playlist_name,
-    M.temp_playlist_name
-  )
+		M.temp_playlist_name,
+		M.temp_playlist_name
+	)
 
-  local handle = io.popen(cmd)
-  local result = handle:read("*a")
-  handle:close()
+	local handle = io.popen(cmd)
+	local result = handle:read("*a")
+	handle:close()
 end
 
 ---Delete temporary playlist. See `apple-music.caveats` for details.
 ---You may have to call this multiple times to remove all temporary playlists.
 ---@usage require('apple-music').cleanup()
 M.cleanup = function()
-  M._cleanup()
-  print("Apple Music: Cleaned up")
+	M._cleanup()
+	print("Apple Music: Cleaned up")
 end
 
 ---Cleanup all temporary playlists, as long as you have less than 10...
@@ -349,96 +349,96 @@ end
 ---There may be weird text written to your screen, but restarting neovim will fix this.
 ---@usage require('apple-music').cleanup_all()
 M.cleanup_all = function()
-  for i = 1, 10 do
-    M._cleanup()
-  end
-  print("Apple Music: Cleaned up all")
+	for i = 1, 10 do
+		M._cleanup()
+	end
+	print("Apple Music: Cleaned up all")
 end
 
 ---Get a list of playlists from your Apple Music library
 ---@usage require('apple-music').get_playlists()
 M.get_playlists = function()
-  local command = [[osascript -e 'tell application "Music" to get name of playlists' -s s]]
+	local command = [[osascript -e 'tell application "Music" to get name of playlists' -s s]]
 
-  local handle = io.popen(command)
-  local result = handle:read("*a")
-  handle:close()
+	local handle = io.popen(command)
+	local result = handle:read("*a")
+	handle:close()
 
-  -- Convert table string into table
-  local result_chunk = "return " .. result
-  local playlists = loadstring(result_chunk)()
+	-- Convert table string into table
+	local result_chunk = "return " .. result
+	local playlists = loadstring(result_chunk)()
 
-  return playlists
+	return playlists
 end
 
 ---Select and play a playlist using Telescope
 ---@usage require('apple-music').select_playlist()
 M.select_playlist = function()
-  local playlists = M.get_playlists()
+	local playlists = M.get_playlists()
 
-  picker.pick("Select a playlist to play", playlists, M.play_playlist)
+	picker.pick("Select a playlist to play", playlists, M.play_playlist)
 end
 
 local remove_duplicates = function(t)
-  local hash = {}
-  local res = {}
+	local hash = {}
+	local res = {}
 
-  for _, v in ipairs(t) do
-    if not hash[v] then
-      res[#res + 1] = v
-      hash[v] = true
-    end
-  end
+	for _, v in ipairs(t) do
+		if not hash[v] then
+			res[#res + 1] = v
+			hash[v] = true
+		end
+	end
 
-  return res
+	return res
 end
 
 ---Get a list of albums from your Apple Music library
 ---@usage require('apple-music').get_albums()
 M.get_albums = function()
-  local command = [[osascript  -e 'tell application "Music" to get album of every track' -s s]]
-  local handle = io.popen(command)
-  local result = handle:read("*a")
-  handle:close()
+	local command = [[osascript  -e 'tell application "Music" to get album of every track' -s s]]
+	local handle = io.popen(command)
+	local result = handle:read("*a")
+	handle:close()
 
-  -- Convert table string into table
-  local result_chunk = "return " .. result
-  local albums = loadstring(result_chunk)()
+	-- Convert table string into table
+	local result_chunk = "return " .. result
+	local albums = loadstring(result_chunk)()
 
-  local unique_albums = remove_duplicates(albums)
+	local unique_albums = remove_duplicates(albums)
 
-  return unique_albums
+	return unique_albums
 end
 
 ---Select and play an album using Telescope
 ---@usage require('apple-music').select_album()
 M.select_album = function()
-  local albums = M.get_albums()
+	local albums = M.get_albums()
 
-  picker.pick("Select an album to play", albums, M.play_album)
+	picker.pick("Select an album to play", albums, M.play_album)
 end
 
 ---Get a list of tracks from your Apple Music library
 ---@usage require('apple-music').get_tracks()
 M.get_tracks = function()
-  local command = [[osascript  -e 'tell application "Music" to get name of every track' -s s]]
-  local handle = io.popen(command)
-  local result = handle:read("*a")
-  handle:close()
+	local command = [[osascript  -e 'tell application "Music" to get name of every track' -s s]]
+	local handle = io.popen(command)
+	local result = handle:read("*a")
+	handle:close()
 
-  -- Convert table string into table
-  local result_chunk = "return " .. result
-  local tracks = loadstring(result_chunk)()
+	-- Convert table string into table
+	local result_chunk = "return " .. result
+	local tracks = loadstring(result_chunk)()
 
-  return tracks
+	return tracks
 end
 
 ---Select and play a track using Telescope
 ---@usage require('apple-music').select_track()
 M.select_track = function()
-  local tracks = M.get_tracks()
+	local tracks = M.get_tracks()
 
-  picker.pick("Select a track to play", tracks, M.play_track)
+	picker.pick("Select a track to play", tracks, M.play_track)
 end
 
 return M

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -441,4 +441,8 @@ M.select_track = function()
 	picker.pick("Select a track to play", tracks, M.play_track)
 end
 
+M.select_playlist_telescope = M.select_playlist
+M.select_album_telescope = M.select_album
+M.select_track_telescope = M.select_track
+
 return M

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -10,99 +10,95 @@
 ---   require('apple-music').play_track("Sir Duke")
 ---<
 ---@brief ]]
-local pickers = require("telescope.pickers")
-local conf = require("telescope.config").values
-local finders = require("telescope.finders")
-local actions = require("telescope.actions")
-local action_state = require("telescope.actions.state")
+local picker = require("apple-music.picker")
 
 local function execute_applescript(script)
-	local command = "osascript -e '" .. script .. "'"
-	local handle = io.popen(command)
-	local result = handle:read("*a")
-	handle:close()
-	return result
+  local command = "osascript -e '" .. script .. "'"
+  local handle = io.popen(command)
+  local result = handle:read("*a")
+  handle:close()
+  return result
 end
 
 local am_run = function(cmd)
-	local script = 'tell application "Music" to ' .. cmd
-	return execute_applescript(script)
+  local script = 'tell application "Music" to ' .. cmd
+  return execute_applescript(script)
 end
 
 local am_app_run = function(cmd)
-	local script = 'tell app "Music" to ' .. cmd
-	return execute_applescript(script)
+  local script = 'tell app "Music" to ' .. cmd
+  return execute_applescript(script)
 end
 
 local execute = function(cmd)
-	local exe = function(cmd)
-		local handle = io.popen(cmd)
-		local result = handle:read("*a")
-		handle:close()
-		return result
-	end
-	return pcall(exe, cmd)
+  local exe = function(cmd)
+    local handle = io.popen(cmd)
+    local result = handle:read("*a")
+    handle:close()
+    return result
+  end
+  return pcall(exe, cmd)
 end
 
 --- Escape single and double quotes from names
 local sanitize_name = function(name)
-	return name:gsub("\\", "\\\\"):gsub("'", "'\\''"):gsub('"', '\\"')
+  return name:gsub("\\", "\\\\"):gsub("'", "'\\''"):gsub('"', '\\"')
 end
 
 local grab_major_os_version = function()
-	local command = [[ osascript -e 'set osver to system version of (system info)' ]]
-	local _, result = execute(command)
-	return tonumber(result:match("%d+"))
+  local command = [[ osascript -e 'set osver to system version of (system info)' ]]
+  local _, result = execute(command)
+  return tonumber(result:match("%d+"))
 end
 
 ---Get the name of the current (playing) track.
 local get_current_trackname = function()
-	local command = [[osascript -e 'tell application "Music" to get name of current track']]
-	local _, result = execute(command)
-	if result == "" then
-		print("Could not get current track")
-		return
-	end
-	return vim.trim(result)
+  local command = [[osascript -e 'tell application "Music" to get name of current track']]
+  local _, result = execute(command)
+  if result == "" then
+    print("Could not get current track")
+    return
+  end
+  return vim.trim(result)
 end
 
 ---Returns whether the provided track is favorited/loved.
 ---@param track string
 local get_favorited_state_of_track = function(track)
-	local command_property = "favorited"
-	-- Before version 14 (Sonoma) the property was called `loved`
-	if grab_major_os_version() < 14 then
-		command_property = "loved"
-	end
-	local command =
-		string.format([[osascript -e 'tell application "Music" to get %s of track "%s"']], command_property, track)
-	local _, result = execute(command)
-	return vim.trim(result) == "true"
+  local command_property = "favorited"
+  -- Before version 14 (Sonoma) the property was called `loved`
+  if grab_major_os_version() < 14 then
+    command_property = "loved"
+  end
+  local command =
+      string.format([[osascript -e 'tell application "Music" to get %s of track "%s"']], command_property, track)
+  local _, result = execute(command)
+  return vim.trim(result) == "true"
 end
 
 ---Set the favorited/loved state of a track.
 ---@param track string
 ---@param state boolean
 local set_track_favorited_state = function(track, state)
-	local command_property = "favorited"
-	-- Before version 14 (Sonoma) the property was called `loved`
-	if grab_major_os_version() < 14 then
-		command_property = "loved"
-	end
+  local command_property = "favorited"
+  -- Before version 14 (Sonoma) the property was called `loved`
+  if grab_major_os_version() < 14 then
+    command_property = "loved"
+  end
 
-	local sanitized_trackname = sanitize_name(track)
-	local command = string.format(
-		[[ osascript -e 'tell application "Music" to set %s of track "%s" to "%s"' ]],
-		command_property,
-		sanitized_trackname,
-		state
-	)
-	execute(command)
-	if state then
-		print("Favorited track: '" .. track .. "'")
-	else
-		print("Unfavorited track: '" .. track .. "'")
-	end
+  local sanitized_trackname = sanitize_name(track)
+  local command = string.format(
+    [[ osascript -e 'tell application "Music" to set %s of track "%s" to "%s"' ]],
+    command_property,
+    sanitized_trackname,
+    state
+  )
+  execute(command)
+  if state then
+    print("Favorited track: '" .. track .. "'")
+  else
+    print("Unfavorited track: '" .. track .. "'")
+  end
 end
 
 ---@mod apple-music.nvim PLUGIN OVERVIEW
@@ -113,54 +109,54 @@ local M = {}
 --- * {temp_playlist_name: string} - The name of the temporary playlist to use
 --- 								(see `apple-music.caveats` for details on temporary playlists)
 M.setup = function(opts)
-	M.temp_playlist_name = opts.temp_playlist_name or "apple-music.nvim"
+  M.temp_playlist_name = opts.temp_playlist_name or "apple-music.nvim"
 
-	-- Cleanup temporary playlists on exit
-	-- TODO: Possible improvements by wrapping in pcall
-	vim.api.nvim_create_autocmd("VimLeave", {
-		callback = function()
-			M.cleanup_all()
-		end,
-	})
+  -- Cleanup temporary playlists on exit
+  -- TODO: Possible improvements by wrapping in pcall
+  vim.api.nvim_create_autocmd("VimLeave", {
+    callback = function()
+      M.cleanup_all()
+    end,
+  })
 end
 
 ---Play a track by title
 ---@param track string: The title of the track to play
 ---@usage require('apple-music').play_track("Sir Duke")
 M.play_track = function(track)
-	print("Playing " .. track)
+  print("Playing " .. track)
 
-	local sanitized = sanitize_name(track)
-	local command = string.format(
-		[[
+  local sanitized = sanitize_name(track)
+  local command = string.format(
+    [[
         osascript -e '
         tell application "Music"
             play track "%s"
         end tell'
     ]],
-		sanitized
-	)
+    sanitized
+  )
 
-	local result = execute(command)
+  local result = execute(command)
 end
 
 ---Play a playlist by name
 ---@param playlist string: The name of the playlist to play
 ---@usage require('apple-music').play_playlist("Slow Dance")
 M.play_playlist = function(playlist)
-	print("Playing playlist: " .. playlist)
+  print("Playing playlist: " .. playlist)
 
-	local sanitized = sanitize_name(playlist)
-	local cmd = string.format(
-		[[
+  local sanitized = sanitize_name(playlist)
+  local cmd = string.format(
+    [[
 		osascript -e '
 			tell application "Music" to play playlist "%s"
 		end'
 	]],
-		sanitized
-	)
+    sanitized
+  )
 
-	execute(cmd)
+  execute(cmd)
 end
 
 ---Play an album by name
@@ -168,11 +164,11 @@ end
 ---@param album string: The name of the album to play
 ---@usage require('apple-music').play_album("Nashville Skyline")
 M.play_album = function(album)
-	print("Playing album: " .. album)
+  print("Playing album: " .. album)
 
-	local sanitized = sanitize_name(album)
-	local command = string.format(
-		[[
+  local sanitized = sanitize_name(album)
+  local command = string.format(
+    [[
         osascript -e '
         tell application "Music"
             set tempPlaylist to make new playlist with properties {name:"%s"}
@@ -183,147 +179,147 @@ M.play_album = function(album)
             play tempPlaylist
         end tell'
     ]],
-		M.temp_playlist_name,
-		sanitized
-	)
+    M.temp_playlist_name,
+    sanitized
+  )
 
-	execute(command)
+  execute(command)
 end
 
 ---Play the next track
 ---@usage require('apple-music').next_track()
 M.next_track = function()
-	am_app_run("play next track")
-	print("Apple Music: Next Track")
+  am_app_run("play next track")
+  print("Apple Music: Next Track")
 end
 
 ---Play the previous track
 ---@usage require('apple-music').previous_track()
 M.previous_track = function()
-	am_run("previous track")
-	print("Apple Music: Previous Track")
+  am_run("previous track")
+  print("Apple Music: Previous Track")
 end
 
 ---Restart the current track
 ---@usage require('apple-music').restart_track()
 M.restart_track = function()
-	am_run("set player position to 0")
-	print("Apple Music: Restarted Track")
+  am_run("set player position to 0")
+  print("Apple Music: Restarted Track")
 end
 
 ---Toggle playback (play/pause)
 ---@usage require('apple-music').toggle_play()
 M.toggle_play = function()
-	am_run("playpause")
-	print("Apple Music: Toggled Playback")
+  am_run("playpause")
+  print("Apple Music: Toggled Playback")
 end
 
 ---Resume playback
 ---@usage require('apple-music').resume()
 M.resume = function()
-	am_run("play")
-	print("Apple Music: Resumed")
+  am_run("play")
+  print("Apple Music: Resumed")
 end
 
 ---Puase Playback
 ---@usage require('apple-music').pause()
 M.pause = function()
-	am_run("pause")
-	print("Apple Music: Paused")
+  am_run("pause")
+  print("Apple Music: Paused")
 end
 
 ---Enable shuffle
 ---@usage require('apple-music').enable_shuffle()
 M.enable_shuffle = function()
-	local cmd = [[ osascript -e 'tell application "Music" to set shuffle enabled to true']]
+  local cmd = [[ osascript -e 'tell application "Music" to set shuffle enabled to true']]
 
-	local handle = io.popen(cmd)
-	local result = handle:read("*a")
-	handle:close()
+  local handle = io.popen(cmd)
+  local result = handle:read("*a")
+  handle:close()
 
-	if result then
-		print("Apple Music: Shuffle enabled")
-	else
-		print("Apple Music: Failed to enable shuffle")
-	end
+  if result then
+    print("Apple Music: Shuffle enabled")
+  else
+    print("Apple Music: Failed to enable shuffle")
+  end
 end
 
 ---Disable shuffle
 ---@usage require('apple-music').disable_shuffle()
 M.disable_shuffle = function()
-	local cmd = [[ osascript -e 'tell application "Music" to set shuffle enabled to false']]
+  local cmd = [[ osascript -e 'tell application "Music" to set shuffle enabled to false']]
 
-	local handle = io.popen(cmd)
-	local result = handle:read("*a")
-	handle:close()
+  local handle = io.popen(cmd)
+  local result = handle:read("*a")
+  handle:close()
 
-	if result then
-		print("Apple Music: Shuffle disabled")
-	else
-		print("Apple Music: Failed to disable shuffle")
-	end
+  if result then
+    print("Apple Music: Shuffle disabled")
+  else
+    print("Apple Music: Failed to disable shuffle")
+  end
 end
 
 ---Favorite current (playing) track.
 ---NOTE: Below macOS 14 (Sonoma), it'll be `loved`.
 ---@usage require('apple-music').favorite_current_track()
 M.favorite_current_track = function()
-	local current_track = get_current_trackname()
-	if not current_track then
-		return
-	end
-	set_track_favorited_state(current_track, true)
+  local current_track = get_current_trackname()
+  if not current_track then
+    return
+  end
+  set_track_favorited_state(current_track, true)
 end
 
 ---Unfavorite current (playing) track.
 ---NOTE: Below macOS 14 (Sonoma), it'll be un-`loved`.
 ---@usage require('apple-music').unfavorite_current_track()
 M.unfavorite_current_track = function()
-	local current_track = get_current_trackname()
-	if not current_track then
-		return
-	end
-	set_track_favorited_state(current_track, false)
+  local current_track = get_current_trackname()
+  if not current_track then
+    return
+  end
+  set_track_favorited_state(current_track, false)
 end
 
 ---Toggle favorite for current (playing) track.
 ---NOTE: Below macOS 14 (Sonoma), it'll toggle `loved`.
 ---@usage require('apple-music').toggle_favorite_current_track()
 M.toggle_favorite_current_track = function()
-	local current_track = get_current_trackname()
-	if not current_track then
-		return
-	end
-	local is_favorited = get_favorited_state_of_track(current_track)
-	set_track_favorited_state(current_track, not is_favorited)
+  local current_track = get_current_trackname()
+  if not current_track then
+    return
+  end
+  local is_favorited = get_favorited_state_of_track(current_track)
+  set_track_favorited_state(current_track, not is_favorited)
 end
 
 ---Toggle shuffle
 ---@usage require('apple-music').toggle_shuffle()
 M.toggle_shuffle = function()
-	if M.shuffle_is_enabled() then
-		M.disable_shuffle()
-		print("Apple Music: Shuffle disabled")
-	else
-		M.enable_shuffle()
-		print("Apple Music: Shuffle enabled")
-	end
+  if M.shuffle_is_enabled() then
+    M.disable_shuffle()
+    print("Apple Music: Shuffle disabled")
+  else
+    M.enable_shuffle()
+    print("Apple Music: Shuffle enabled")
+  end
 end
 
 ---Determine if shuffle is enabled
 ---@usage require('apple-music').shuffle_is_enabled()
 M.shuffle_is_enabled = function()
-	local cmd = [[osascript -e 'tell application "Music" to get shuffle enabled']]
-	local handle = io.popen(cmd)
-	local result = handle:read("*a")
-	handle:close()
-	local is_enabled = result:match("true") and true or false
-	return is_enabled
+  local cmd = [[osascript -e 'tell application "Music" to get shuffle enabled']]
+  local handle = io.popen(cmd)
+  local result = handle:read("*a")
+  handle:close()
+  local is_enabled = result:match("true") and true or false
+  return is_enabled
 end
 
 M._cleanup = function()
-	local cmd = string.format(
-		[[
+  local cmd = string.format(
+    [[
 		osascript -e '
 		tell application "Music"
 			if (exists playlist "%s") then
@@ -331,21 +327,21 @@ M._cleanup = function()
 			end if
 		end tell'
 		]],
-		M.temp_playlist_name,
-		M.temp_playlist_name
-	)
+    M.temp_playlist_name,
+    M.temp_playlist_name
+  )
 
-	local handle = io.popen(cmd)
-	local result = handle:read("*a")
-	handle:close()
+  local handle = io.popen(cmd)
+  local result = handle:read("*a")
+  handle:close()
 end
 
 ---Delete temporary playlist. See `apple-music.caveats` for details.
 ---You may have to call this multiple times to remove all temporary playlists.
 ---@usage require('apple-music').cleanup()
 M.cleanup = function()
-	M._cleanup()
-	print("Apple Music: Cleaned up")
+  M._cleanup()
+  print("Apple Music: Cleaned up")
 end
 
 ---Cleanup all temporary playlists, as long as you have less than 10...
@@ -353,143 +349,96 @@ end
 ---There may be weird text written to your screen, but restarting neovim will fix this.
 ---@usage require('apple-music').cleanup_all()
 M.cleanup_all = function()
-	for i = 1, 10 do
-		M._cleanup()
-	end
-	print("Apple Music: Cleaned up all")
+  for i = 1, 10 do
+    M._cleanup()
+  end
+  print("Apple Music: Cleaned up all")
 end
 
 ---Get a list of playlists from your Apple Music library
 ---@usage require('apple-music').get_playlists()
 M.get_playlists = function()
-	local command = [[osascript -e 'tell application "Music" to get name of playlists' -s s]]
+  local command = [[osascript -e 'tell application "Music" to get name of playlists' -s s]]
 
-	local handle = io.popen(command)
-	local result = handle:read("*a")
-	handle:close()
+  local handle = io.popen(command)
+  local result = handle:read("*a")
+  handle:close()
 
-	-- Convert table string into table
-	local result_chunk = "return " .. result
-	local playlists = loadstring(result_chunk)()
+  -- Convert table string into table
+  local result_chunk = "return " .. result
+  local playlists = loadstring(result_chunk)()
 
-	return playlists
+  return playlists
 end
 
 ---Select and play a playlist using Telescope
----@usage require('apple-music').select_playlist_telescope()
-M.select_playlist_telescope = function()
-	local playlists = M.get_playlists()
+---@usage require('apple-music').select_playlist()
+M.select_playlist = function()
+  local playlists = M.get_playlists()
 
-	pickers
-		.new({}, {
-			prompt_title = "Select a playlist to play",
-			finder = finders.new_table({
-				results = playlists,
-			}),
-			sorter = conf.generic_sorter({}),
-			attach_mappings = function(prompt_bufnr, map)
-				actions.select_default:replace(function()
-					actions.close(prompt_bufnr)
-					local selection = action_state.get_selected_entry()
-					M.play_playlist(selection[1])
-				end)
-				return true
-			end,
-		})
-		:find()
+  picker.pick("Select a playlist to play", playlists, M.play_playlist)
 end
 
 local remove_duplicates = function(t)
-	local hash = {}
-	local res = {}
+  local hash = {}
+  local res = {}
 
-	for _, v in ipairs(t) do
-		if not hash[v] then
-			res[#res + 1] = v
-			hash[v] = true
-		end
-	end
+  for _, v in ipairs(t) do
+    if not hash[v] then
+      res[#res + 1] = v
+      hash[v] = true
+    end
+  end
 
-	return res
+  return res
 end
 
 ---Get a list of albums from your Apple Music library
 ---@usage require('apple-music').get_albums()
 M.get_albums = function()
-	local command = [[osascript  -e 'tell application "Music" to get album of every track' -s s]]
-	local handle = io.popen(command)
-	local result = handle:read("*a")
-	handle:close()
+  local command = [[osascript  -e 'tell application "Music" to get album of every track' -s s]]
+  local handle = io.popen(command)
+  local result = handle:read("*a")
+  handle:close()
 
-	-- Convert table string into table
-	local result_chunk = "return " .. result
-	local albums = loadstring(result_chunk)()
+  -- Convert table string into table
+  local result_chunk = "return " .. result
+  local albums = loadstring(result_chunk)()
 
-	local unique_albums = remove_duplicates(albums)
+  local unique_albums = remove_duplicates(albums)
 
-	return unique_albums
+  return unique_albums
 end
 
 ---Select and play an album using Telescope
----@usage require('apple-music').select_album_telescope()
-M.select_album_telescope = function()
-	local albums = M.get_albums()
+---@usage require('apple-music').select_album()
+M.select_album = function()
+  local albums = M.get_albums()
 
-	pickers
-		.new({}, {
-			prompt_title = "Select an album to play",
-			finder = finders.new_table({
-				results = albums,
-			}),
-			sorter = conf.generic_sorter({}),
-			attach_mappings = function(prompt_bufnr, map)
-				actions.select_default:replace(function()
-					actions.close(prompt_bufnr)
-					local selection = action_state.get_selected_entry()
-					M.play_album(selection[1])
-				end)
-				return true
-			end,
-		})
-		:find()
+  picker.pick("Select an album to play", albums, M.play_album)
 end
 
 ---Get a list of tracks from your Apple Music library
 ---@usage require('apple-music').get_tracks()
 M.get_tracks = function()
-	local command = [[osascript  -e 'tell application "Music" to get name of every track' -s s]]
-	local handle = io.popen(command)
-	local result = handle:read("*a")
-	handle:close()
+  local command = [[osascript  -e 'tell application "Music" to get name of every track' -s s]]
+  local handle = io.popen(command)
+  local result = handle:read("*a")
+  handle:close()
 
-	-- Convert table string into table
-	local result_chunk = "return " .. result
-	local tracks = loadstring(result_chunk)()
+  -- Convert table string into table
+  local result_chunk = "return " .. result
+  local tracks = loadstring(result_chunk)()
 
-	return tracks
+  return tracks
 end
 
 ---Select and play a track using Telescope
----@usage require('apple-music').select_track_telescope()
-M.select_track_telescope = function()
-	local tracks = M.get_tracks()
-	pickers
-		.new({}, {
-			prompt_title = "Select a track to play",
-			finder = finders.new_table({
-				results = tracks,
-			}),
-			sorter = conf.generic_sorter({}),
-			attach_mappings = function(prompt_bufnr, map)
-				actions.select_default:replace(function()
-					actions.close(prompt_bufnr)
-					local selection = action_state.get_selected_entry()
-					M.play_track(selection[1])
-				end)
-				return true
-			end,
-		})
-		:find()
+---@usage require('apple-music').select_track()
+M.select_track = function()
+  local tracks = M.get_tracks()
+
+  picker.pick("Select a track to play", tracks, M.play_track)
 end
 
 return M

--- a/lua/apple-music/picker.lua
+++ b/lua/apple-music/picker.lua
@@ -17,7 +17,7 @@ local function telescope_pick(pickers, title, items, on_select)
 			results = items,
 		}),
 		sorter = conf.generic_sorter({}),
-		attach_mappings = function(prompt_bufnr, map)
+		attach_mappings = function(prompt_bufnr, _)
 			actions.select_default:replace(function()
 				actions.close(prompt_bufnr)
 				local selection = action_state.get_selected_entry()

--- a/lua/apple-music/picker.lua
+++ b/lua/apple-music/picker.lua
@@ -6,28 +6,27 @@ local M = {}
 --- @param items table List of items to pick from
 --- @param on_select function(item: string) Function to call when an item is selected
 local function telescope_pick(pickers, title, items, on_select)
-  local finders = require("telescope.finders")
-  local conf = require("telescope.config").values
-  local actions = require("telescope.actions")
-  local action_state = require("telescope.actions.state")
+	local finders = require("telescope.finders")
+	local conf = require("telescope.config").values
+	local actions = require("telescope.actions")
+	local action_state = require("telescope.actions.state")
 
-  pickers
-      .new({}, {
-        prompt_title = title,
-        finder = finders.new_table({
-          results = items,
-        }),
-        sorter = conf.generic_sorter({}),
-        attach_mappings = function(prompt_bufnr, map)
-          actions.select_default:replace(function()
-            actions.close(prompt_bufnr)
-            local selection = action_state.get_selected_entry()
-            on_select(selection[1])
-          end)
-          return true
-        end,
-      })
-      :find()
+	pickers.new({}, {
+		prompt_title = title,
+		finder = finders.new_table({
+			results = items,
+		}),
+		sorter = conf.generic_sorter({}),
+		attach_mappings = function(prompt_bufnr, map)
+			actions.select_default:replace(function()
+				actions.close(prompt_bufnr)
+				local selection = action_state.get_selected_entry()
+				on_select(selection[1])
+			end)
+			return true
+		end,
+	})
+			:find()
 end
 
 --- Pick an item from a list
@@ -37,19 +36,19 @@ end
 --- @param items table List of items to pick from
 --- @param on_select function(item: string) Function to call when an item is selected
 M.pick = function(title, items, on_select)
-  local telescope_exists, telescope_pickers = pcall(require, 'telescope.pickers')
-  if telescope_exists then
-    telescope_pick(telescope_pickers, title, items, on_select)
-    return
-  end
+	local telescope_exists, telescope_pickers = pcall(require, 'telescope.pickers')
+	if telescope_exists then
+		telescope_pick(telescope_pickers, title, items, on_select)
+		return
+	end
 
-  vim.ui.select(items, {
-    prompt = title
-  }, function(item)
-    if item then
-      on_select(item)
-    end
-  end)
+	vim.ui.select(items, {
+		prompt = title
+	}, function(item)
+		if item then
+			on_select(item)
+		end
+	end)
 end
 
 return M

--- a/lua/apple-music/picker.lua
+++ b/lua/apple-music/picker.lua
@@ -1,0 +1,55 @@
+local M = {}
+
+--- Use telescope to pick an item from a list
+--- @param pickers table Telescope pickers module
+--- @param title string Title of the picker
+--- @param items table List of items to pick from
+--- @param on_select function(item: string) Function to call when an item is selected
+local function telescope_pick(pickers, title, items, on_select)
+  local finders = require("telescope.finders")
+  local conf = require("telescope.config").values
+  local actions = require("telescope.actions")
+  local action_state = require("telescope.actions.state")
+
+  pickers
+      .new({}, {
+        prompt_title = title,
+        finder = finders.new_table({
+          results = items,
+        }),
+        sorter = conf.generic_sorter({}),
+        attach_mappings = function(prompt_bufnr, map)
+          actions.select_default:replace(function()
+            actions.close(prompt_bufnr)
+            local selection = action_state.get_selected_entry()
+            on_select(selection[1])
+          end)
+          return true
+        end,
+      })
+      :find()
+end
+
+--- Pick an item from a list
+--- If telescope is available, it will be used to pick the item
+--- Otherwise, `vim.ui.select` will be used
+--- @param title string Title of the picker
+--- @param items table List of items to pick from
+--- @param on_select function(item: string) Function to call when an item is selected
+M.pick = function(title, items, on_select)
+  local telescope_exists, telescope_pickers = pcall(require, 'telescope.pickers')
+  if telescope_exists then
+    telescope_pick(telescope_pickers, title, items, on_select)
+    return
+  end
+
+  vim.ui.select(items, {
+    prompt = title
+  }, function(item)
+    if item then
+      on_select(item)
+    end
+  end)
+end
+
+return M


### PR DESCRIPTION
This PR makes Telescope an optional dependency by using `vim.ui.select` when it's not installed.

### Overview

A new `picker.lua` module abstracts the picker logic. For now, there is support for telescope and `vim.ui.select`, but it's easy to add support for fzf-lua(https://github.com/p5quared/apple-music.nvim/issues/20), for example

## Summary by Sourcery

Enhancements:
- Introduce a new `picker.lua` module to abstract the picker logic.