### PR TITLE
Doc/opting out of telescope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Neovim Apple Music Plugin
 
-This Neovim plugin allows you to control Apple Music directly from within Neovim using Lua and Telescope. You can play tracks, playlists, and albums, and control playback without leaving your favorite text editor.
+This Neovim plugin allows you to control Apple Music directly from within Neovim using Lua and Telescope (or `vim.ui.select`).
+You can play tracks, playlists, and albums, and control playback without leaving your favorite text editor.
 
 ![Demo of Selecting Album via Telescope](demos/select_album.gif)
 
@@ -37,7 +38,7 @@ Here is how I have this plugin setup, minus the dev stuff.
 I think this is a good overview of the main functionality as well.
 Toggling playback is arguably just as easy to do with general keyboard shortcuts
 (nowadays you often have media keys). I think the ability to browse
-and play via telescope is the the most useful feature of this plugin.
+and play via telescope (or `vim.ui.select`) is the the most useful feature of this plugin.
 
 Note that you have to manually cleanup the temporary playlists created by this plugin.
 In the future I may try to come up with an autocmd solution.
@@ -83,7 +84,6 @@ Before opening pull requests, please run `stylua` locally.
 
 ## Acknowledgements
 
-- [nvim-telescope/telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
 - [mcthomas/Apple-Music-CLI-Player](https://github.com/mcthomas/Apple-Music-CLI-Player)
     - Much of the Apple Script was taken/heavily inspired from this repo.
     I probably could have pieced together a lot of the basic stuff, but probably

--- a/lua/apple-music/init.lua
+++ b/lua/apple-music/init.lua
@@ -371,7 +371,7 @@ M.get_playlists = function()
 	return playlists
 end
 
----Select and play a playlist using Telescope
+---Select and play a playlist
 ---@usage require('apple-music').select_playlist()
 M.select_playlist = function()
 	local playlists = M.get_playlists()
@@ -410,7 +410,7 @@ M.get_albums = function()
 	return unique_albums
 end
 
----Select and play an album using Telescope
+---Select and play an album from your library
 ---@usage require('apple-music').select_album()
 M.select_album = function()
 	local albums = M.get_albums()
@@ -433,7 +433,7 @@ M.get_tracks = function()
 	return tracks
 end
 
----Select and play a track using Telescope
+---Select and play a track from your library
 ---@usage require('apple-music').select_track()
 M.select_track = function()
 	local tracks = M.get_tracks()
@@ -441,8 +441,16 @@ M.select_track = function()
 	picker.pick("Select a track to play", tracks, M.play_track)
 end
 
+---Select and play a playlist using Telescope
+---@usage require('apple-music').select_playlist()
 M.select_playlist_telescope = M.select_playlist
+
+---Select and play an album from your library using Telescope
+---@usage require('apple-music').select_album()
 M.select_album_telescope = M.select_album
+
+---Select and play a track from your library using Telescope
+---@usage require('apple-music').select_track()
 M.select_track_telescope = M.select_track
 
 return M


### PR DESCRIPTION
## Summary by Sourcery

Modify the Apple Music plugin to support optional Telescope integration and provide alternative selection methods

New Features:
- Introduce alternative Telescope-specific methods for selecting playlists, albums, and tracks

Enhancements:
- Add support for using vim.ui.select as an alternative to Telescope for selecting music items

Documentation:
- Update README to clarify that the plugin supports both Telescope and vim.ui.select for music selection