### PR TITLE
feat(picker): add support to fzf-lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Neovim Apple Music Plugin
 
-This Neovim plugin allows you to control Apple Music directly from within Neovim using Lua and Telescope (or `vim.ui.select`).
+This Neovim plugin allows you to control Apple Music directly from within Neovim using Lua and Telescope/fzf-lua (or `vim.ui.select`).
 You can play tracks, playlists, and albums, and control playback without leaving your favorite text editor.
 
 ![Demo of Selecting Album via Telescope](demos/select_album.gif)
@@ -10,7 +10,7 @@ You can play tracks, playlists, and albums, and control playback without leaving
 - Play specific tracks, playlists, or albums.
 - Control playback (play, pause, next track, previous track, toggle play/pause).
 - Enable or disable shuffle.
-- View and select entries using a picker. (if you don't have Telescope installed, `vim.ui.select` is used instead)
+- View and select entries using a picker. (if you don't have Telescope/fzf-lua installed, `vim.ui.select` is used instead)
 
 ## Installation
 
@@ -22,7 +22,10 @@ Here is how I have this plugin setup, minus the dev stuff.
 {
     'p5quared/apple-music.nvim',
     -- Optional dependencies
-    -- dependencies = { 'nvim-telescope/telescope.nvim' },
+    -- dependencies = {
+    --   'nvim-telescope/telescope.nvim'
+    --   'ibhagwan/fzf-lua',
+    -- },
     config = true,
     keys = {
         { "<leader>amp", function() require("apple-music").toggle_play() end,               desc = "Toggle [P]layback" },
@@ -38,7 +41,7 @@ Here is how I have this plugin setup, minus the dev stuff.
 I think this is a good overview of the main functionality as well.
 Toggling playback is arguably just as easy to do with general keyboard shortcuts
 (nowadays you often have media keys). I think the ability to browse
-and play via telescope (or `vim.ui.select`) is the the most useful feature of this plugin.
+and play via telescope/fzf-lua (or `vim.ui.select`) is the the most useful feature of this plugin.
 
 Note that you have to manually cleanup the temporary playlists created by this plugin.
 In the future I may try to come up with an autocmd solution.
@@ -50,6 +53,7 @@ You can customize the plugin by passing options to the `setup` function:
 ```lua
 require('apple-music').setup({
   temp_playlist_name = "nvim_apple_music_temp"  -- Custom temporary playlist name
+  picker = "auto",  -- Options: "auto", "telescope", "fzf-lua", or "select"
 })
 ```
 

--- a/lua/apple-music/notify.lua
+++ b/lua/apple-music/notify.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+--- Notifies the user with a error message
+--- @param message string Message to display
+M.error = function(message)
+	vim.notify(message, vim.log.levels.ERROR, {
+		title = "apple-music.nvim",
+	})
+end
+
+return M

--- a/lua/apple-music/picker.lua
+++ b/lua/apple-music/picker.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local notify = require("apple-music.notify")
+
 --- Use telescope to pick an item from a list
 --- @param pickers table Telescope pickers module
 --- @param title string Title of the picker
@@ -30,26 +32,72 @@ local function telescope_pick(pickers, title, items, on_select)
 		:find()
 end
 
---- Pick an item from a list
---- If telescope is available, it will be used to pick the item
---- Otherwise, `vim.ui.select` will be used
+--- Use fzf-lua to pick an item from a list
+--- @param fzf_lua table Fzf-lua module
 --- @param title string Title of the picker
 --- @param items table List of items to pick from
 --- @param on_select function(item: string) Function to call when an item is selected
-M.pick = function(title, items, on_select)
-	local telescope_exists, telescope_pickers = pcall(require, "telescope.pickers")
-	if telescope_exists then
-		telescope_pick(telescope_pickers, title, items, on_select)
+local function fzf_lua_pick(fzf_lua, title, items, on_select)
+	fzf_lua.fzf_exec(items, {
+		prompt = title .. "> ",
+		actions = {
+			["default"] = function(selected)
+				on_select(selected[1])
+			end,
+		},
+	})
+end
+
+--- @alias Picker "auto" | "telescope" | "fzf-lua" | "select"
+
+--- Pick an item from a list
+--- If telescope is available, it will be used to pick the item
+--- Otherwise, `vim.ui.select` will be used
+--- @param picker Picker Title of the picker
+--- @param title string Title of the picker
+--- @param items table List of items to pick from
+--- @param on_select function(item: string) Function to call when an item is selected
+M.pick = function(picker, title, items, on_select)
+	if picker == "auto" or picker == "telescope" then
+		local telescope_exists, telescope_pickers = pcall(require, "telescope.pickers")
+		if telescope_exists then
+			telescope_pick(telescope_pickers, title, items, on_select)
+			return
+		end
+
+		-- If the picker is not "auto", we don't want to fall back to vim.ui.select
+		if picker == "telescope" then
+			notify.error("Telescope not found. Install Telescope or change the picker.")
+			return
+		end
+	end
+
+	if picker == "auto" or picker == "fzf-lua" then
+		local fzf_lua_exists, fzf_lua = pcall(require, "fzf-lua")
+		if fzf_lua_exists then
+			fzf_lua_pick(fzf_lua, title, items, on_select)
+			return
+		end
+
+		-- If the picker is not "auto", we don't want to fall back to vim.ui.select
+		if picker == "fzf-lua" then
+			notify.error("Fzf-lua not found. Install Fzf-lua or change the picker.")
+			return
+		end
+	end
+
+	if picker == "auto" or picker == "select" then
+		vim.ui.select(items, {
+			prompt = title,
+		}, function(item)
+			if item then
+				on_select(item)
+			end
+		end)
 		return
 	end
 
-	vim.ui.select(items, {
-		prompt = title,
-	}, function(item)
-		if item then
-			on_select(item)
-		end
-	end)
+	notify.error("Unknown picker: " .. picker .. ". Available pickers: auto, telescope, fzf-lua, select")
 end
 
 return M


### PR DESCRIPTION
Closes: #20 

This PR adds support for [fzf-lua](https://github.com/ibhagwan/fzf-lua).

### Overview

- A new `picker` config options was added to setup. With this option the user may choose the picker, if the user doesn't set this option, the default value is `auto` and it will try the pickers in the following order: telescope, fzf-lua, vim.ui.select
- A new module variable `config` used to store the current config.
- A new `notify.lua` module used to abstract `vim.notify` so we don't need to pass the title and the `vim.log.levels` manually.
- Added `--- @deprecated` to the `_telescope` functions

### Behavior

If `config.picker` is set to `auto` we try all the pickers until we found one that works.
If `config.picker` is set to a picker, we only try this picker and, if not found, we show an error message to the user
If `config.picker` is set to a unknown picker, we show an error message to the user